### PR TITLE
improve PR workflow

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -10,6 +10,12 @@ jobs:
       - name: Is this a fork
         run: |
           fork=$(jq --raw-output .pull_request.head.repo.fork "${GITHUB_EVENT_PATH}");echo "::set-env name=fork::$fork"
+          if $fork == "false"
+          then
+            echo "This is not a fork, we shall deploy a preview."
+          else
+            echo "This is a fork, we shall not deploy a preview."
+          fi
             
       
       - uses: actions/checkout@v1

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -10,7 +10,7 @@ jobs:
       - name: Is this a fork
         run: |
           fork=$(jq --raw-output .pull_request.head.repo.fork "${GITHUB_EVENT_PATH}");echo "::set-env name=fork::$fork"
-          if $fork == 'false'
+          if [ $fork == 'false' ]
           then
             echo "This is not a fork, we shall deploy a preview."
           else

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -10,7 +10,7 @@ jobs:
       - name: Is this a fork
         run: |
           fork=$(jq --raw-output .pull_request.head.repo.fork "${GITHUB_EVENT_PATH}");echo "::set-env name=fork::$fork"
-          if $fork == "false"
+          if $fork == false
           then
             echo "This is not a fork, we shall deploy a preview."
           else

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,15 +1,23 @@
 on: pull_request
-
-name: Render-Book-from-PR
+  
+name: PR-workflow
 
 jobs:
   bookdown:
-    name: Render-Book
+    name: Render Book
     runs-on: macOS-latest
     steps:
+      - name: Is this a fork
+        run: |
+          fork=$(jq --raw-output .pull_request.head.repo.fork "${GITHUB_EVENT_PATH}");echo "::set-env name=fork::$fork"
+            
+      
       - uses: actions/checkout@v1
+        
       - uses: r-lib/actions/setup-r@v1
+      
       - uses: r-lib/actions/setup-pandoc@v1
+      
       - name: Query dependencies
         run:
           Rscript -e "install.packages('remotes')" -e "saveRDS(remotes::dev_package_deps(dependencies = TRUE), 'depends.Rds', version = 2)"
@@ -27,28 +35,37 @@ jobs:
 
       - name: Render Book
         run: Rscript -e 'bookdown::render_book("index.Rmd")'
-      - name: If this is a fork stop here
-        run: |
-          fork=$(jq --raw-output .pull_request.head.repo.fork "${GITHUB_EVENT_PATH}")
-          if [ $fork == true ]; then
-             echo "This is a fork, no preview rendering"
-             exit 78;
-          else
-             echo "This is not a fork, on to preview rendering"
-          fi
+        
       - uses: actions/setup-node@v1
+        if: env.fork == 'false'
         with:
           node-version: "12.x"
+          
       - name: Install Netlify CLI
+        if: env.fork == 'false'
         run: npm install netlify-cli -g
+        
       - name: Deploy to Netlify (test)
+        if: env.fork == 'false'
         run: DEPLOY_URL=$(netlify deploy --site ${{ secrets.NETLIFY_SITE_ID }} --auth ${{ secrets.NETLIFY_AUTH_TOKEN }} --dir=docs --json | jq '.deploy_url' --raw-output);echo "::set-env name=DEPLOY_URL::$DEPLOY_URL"
-      - name: Create commit comment
-        uses: peter-evans/commit-comment@v1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          sha: ${{ github.event.pull_request.head.sha }}
-          body: |
-            You can go look at [the preview][1]. :bike: :boat:
-
-            [1]: ${process.env.DEPLOY_URL}
+                
+      - name: Create check
+        if: env.fork == 'false'
+        run: |
+          curl --request POST \
+          --url https://api.github.com/repos/${{ github.repository }}/check-runs \
+          --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' \
+          --header 'Accept: application/vnd.github.antiope-preview+json' \
+          --header 'content-type: application/json' \
+          --data '{
+            "name": "Preview Book",
+            "external_id": "42",
+            "head_sha": "${{ github.event.pull_request.head.sha }}",
+            "conclusion": "success",
+            "html_url": "${{ env.DEPLOY_URL }}",
+            "details_url": "${{ env.DEPLOY_URL }}",
+            "output": {
+                "title": "Preview link",
+                "summary": "[Preview link](${{ env.DEPLOY_URL }}) :rocket:"
+            }
+            }'

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -10,6 +10,7 @@ jobs:
       - name: Is this a fork
         run: |
           fork=$(jq --raw-output .pull_request.head.repo.fork "${GITHUB_EVENT_PATH}");echo "::set-env name=fork::$fork"
+          echo $fork
           if $fork == false
           then
             echo "This is not a fork, we shall deploy a preview."

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -10,8 +10,7 @@ jobs:
       - name: Is this a fork
         run: |
           fork=$(jq --raw-output .pull_request.head.repo.fork "${GITHUB_EVENT_PATH}");echo "::set-env name=fork::$fork"
-          echo $fork
-          if $fork == false
+          if $fork == 'false'
           then
             echo "This is not a fork, we shall deploy a preview."
           else


### PR DESCRIPTION
* Now preview steps are cleanly skipped for forks. [Example in another repo](https://github.com/ropensci-org/blog-guidance/pull/89/checks?check_run_id=466995315).

* There's no longer one comment per commit. Advantage: less spamming. Downside: the preview URL is now _three_ clicks away, not one. 

1. Click on "Show all checks".
2. Click on "details" for the second check (check that's called "Preview book)
3. There, click on the preview link.

I tried adding the preview URL as details URL like what Netlify does for Hugo websites but I can't. I suppose it's because I don't host the app used to create the check (that app being GitHub actions).